### PR TITLE
Fix stale free space from XFS lazy superblock counters

### DIFF
--- a/src/teslausb/filesystem.py
+++ b/src/teslausb/filesystem.py
@@ -176,6 +176,11 @@ class RealFilesystem(Filesystem):
 
     def statvfs(self, path: Path) -> StatVfsResult:
         try:
+            # XFS lazy superblock counters (sb_lazysbcount) aggregate per-CPU
+            # free block counts on demand. After unlink(), the cached aggregate
+            # is stale. The first statvfs() triggers aggregation; the second
+            # reads the accurate result (~0.5ms total).
+            os.statvfs(path)
             st = os.statvfs(path)
             return StatVfsResult(
                 block_size=st.f_frsize,


### PR DESCRIPTION
After deleting reflinked snapshots, os.statvfs() returns stale values because XFS lazy superblock counters (sb_lazysbcount) only aggregate per-CPU free block counts on demand. This caused cleanup_if_needed() to delete all snapshots unnecessarily since it never saw free space increase.

Call os.statvfs() twice: the first triggers counter aggregation, the second reads the accurate result (~0.5ms overhead).