### PR TITLE
Harden syncfs: cache libc handle, guard missing symbol, fix 3.9 compat

### DIFF
--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -271,10 +271,8 @@ class TestRealFilesystem:
         """statvfs flushes the XFS journal via syncfs before reading counters."""
         fs = RealFilesystem()
         expected = os.statvfs(tmp_path)
-        with (
-            patch("teslausb.filesystem._syncfs") as mock_syncfs,
-            patch("teslausb.filesystem.os.statvfs", return_value=expected),
-        ):
+        with patch("teslausb.filesystem._syncfs") as mock_syncfs, \
+             patch("teslausb.filesystem.os.statvfs", return_value=expected):
             result = fs.statvfs(tmp_path)
             mock_syncfs.assert_called_once()
             assert result.block_size == expected.f_frsize


### PR DESCRIPTION
Address review feedback on #36:
- Cache the resolved libc syncfs function at module scope instead of calling find_library/CDLL on every statvfs() invocation
- Guard against missing syncfs symbol with getattr and set proper argtypes/restype for safer ctypes calls
- Replace parenthesized with-statement (Python 3.10+) with backslash continuation for Python 3.9 compatibility