### PR TITLE
Fix Photobooth path to be under TeslaCam directory

### DIFF
--- a/src/teslausb/archive.py
+++ b/src/teslausb/archive.py
@@ -311,8 +311,8 @@ class ArchiveManager:
         "SavedClips": "TeslaCam/SavedClips",
         "SentryClips": "TeslaCam/SentryClips",
         "RecentClips": "TeslaCam/RecentClips",
+        "Photobooth": "TeslaCam/Photobooth",
         "TrackMode": "TeslaTrackMode",
-        "Photobooth": "Photobooth",
     }
 
     def __init__(
@@ -382,7 +382,7 @@ class ArchiveManager:
                 dirs.append((path, "TrackMode"))
 
         if self.archive_photobooth:
-            path = snapshot_mount / "Photobooth"
+            path = snapshot_mount / "TeslaCam" / "Photobooth"
             if self.fs.exists(path):
                 dirs.append((path, "Photobooth"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def mock_fs_with_teslacam(mock_fs: MockFilesystem) -> MockFilesystem:
     fs.write_bytes(event2 / "2024-01-15_11-00-00-front.mp4", b"x" * 600_000)
 
     # Create Photobooth structure
-    photobooth = snap_dir / "mnt" / "Photobooth"
+    photobooth = base / "Photobooth"
     fs.mkdir(photobooth, parents=True)
     fs.write_bytes(photobooth / "selfie_2025-01-01.png", b"x" * 300_000)
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -628,8 +628,8 @@ class TestDeleteArchivedFiles:
         fs = MockFilesystem()
 
         # Set up Photobooth structure
-        fs.mkdir(Path("/cam_mount/Photobooth"), parents=True)
-        fs.write_text(Path("/cam_mount/Photobooth/selfie_2025-01-01.png"), "x" * 1000)
+        fs.mkdir(Path("/cam_mount/TeslaCam/Photobooth"), parents=True)
+        fs.write_text(Path("/cam_mount/TeslaCam/Photobooth/selfie_2025-01-01.png"), "x" * 1000)
 
         fs.mkdir(Path("/backingfiles/snapshots"), parents=True)
         snapshot_manager = SnapshotManager(
@@ -659,7 +659,7 @@ class TestDeleteArchivedFiles:
 
         assert deleted == 1
         assert skipped == 0
-        assert not fs.exists(Path("/cam_mount/Photobooth/selfie_2025-01-01.png"))
+        assert not fs.exists(Path("/cam_mount/TeslaCam/Photobooth/selfie_2025-01-01.png"))
 
     def test_delete_ignores_unknown_directory(self):
         """Test that unknown directory names are logged and skipped."""


### PR DESCRIPTION
Photobooth folder lives at TeslaCam/Photobooth on the Tesla USB drive, not at the root. Fix the archive source path, deletion path mapping, and test fixtures to use the correct location.