### PR TITLE
[codex] Guard active snapshots across processes

### DIFF
--- a/src/teslausb/snapshot.py
+++ b/src/teslausb/snapshot.py
@@ -10,22 +10,26 @@ Design principles:
 - If .toc exists, the snapshot is complete and valid
 - If .toc doesn't exist, the snapshot is incomplete and should be deleted
 - State (READY vs ARCHIVING) is derived from refcount, not stored
+- Cross-process use is detected with a kernel lock on snap.lock
 - Only immutable facts (id, path, created_at) are persisted to metadata.json
 """
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
+import os
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Iterator
+from typing import TextIO
 
-from .filesystem import Filesystem
+from .filesystem import Filesystem, RealFilesystem
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +77,7 @@ class Snapshot:
     path: Path
     created_at: datetime
     refcount: int = 0
+    externally_locked: bool = False
 
     @property
     def image_path(self) -> Path:
@@ -90,9 +95,16 @@ class Snapshot:
         return self.path / "metadata.json"
 
     @property
+    def lock_path(self) -> Path:
+        """Path to the cross-process lock file."""
+        return self.path / "snap.lock"
+
+    @property
     def state(self) -> SnapshotState:
         """Current state, derived from refcount."""
-        return SnapshotState.ARCHIVING if self.refcount > 0 else SnapshotState.READY
+        if self.refcount > 0 or self.externally_locked:
+            return SnapshotState.ARCHIVING
+        return SnapshotState.READY
 
     @property
     def is_complete(self) -> bool:
@@ -106,7 +118,7 @@ class Snapshot:
     @property
     def is_deletable(self) -> bool:
         """Whether the snapshot can be deleted."""
-        return self.refcount == 0
+        return self.refcount == 0 and not self.externally_locked
 
     def to_dict(self) -> dict:
         """Serialize to dictionary.
@@ -197,10 +209,12 @@ class SnapshotManager:
     _next_id: int = 0
     _lock: threading.RLock = field(default_factory=threading.RLock)
     _creating: bool = False
+    _process_lock_files: dict[int, TextIO] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Initialize manager and load existing snapshots."""
         self._lock = threading.RLock()
+        self._process_lock_files = {}
         self._load_snapshots()
 
     def _load_snapshots(self) -> None:
@@ -290,6 +304,71 @@ class SnapshotManager:
         except Exception as e:
             logger.warning(f"Failed to save snapshot metadata: {e}")
 
+    def _process_locks_enabled(self) -> bool:
+        """Whether OS-level snapshot locks are available."""
+        return isinstance(self.fs, RealFilesystem)
+
+    def _acquire_process_lock(self, snapshot: Snapshot) -> None:
+        """Acquire the cross-process lock for a snapshot."""
+        if not self._process_locks_enabled() or snapshot.id in self._process_lock_files:
+            return
+
+        lock_file = snapshot.lock_path.open("a+")
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.write(f"{os.getpid()}\n")
+            lock_file.flush()
+        except BlockingIOError as e:
+            lock_file.close()
+            raise SnapshotInUseError(
+                f"Snapshot {snapshot.id} is locked by another process"
+            ) from e
+
+        self._process_lock_files[snapshot.id] = lock_file
+
+    def _release_process_lock(self, snapshot: Snapshot) -> None:
+        """Release the cross-process lock for a snapshot."""
+        lock_file = self._process_lock_files.pop(snapshot.id, None)
+        if lock_file is None:
+            return
+
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_file.close()
+
+    def _is_locked_by_other_process(self, snapshot: Snapshot) -> bool:
+        """Return whether another process currently holds a snapshot lock."""
+        if not self._process_locks_enabled() or snapshot.id in self._process_lock_files:
+            return False
+        if not snapshot.lock_path.exists():
+            return False
+
+        try:
+            lock_file = snapshot.lock_path.open("r")
+        except FileNotFoundError:
+            return False
+
+        with lock_file:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return True
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            return False
+
+    def _refresh_external_lock(self, snapshot: Snapshot) -> None:
+        """Refresh cross-process lock state for one snapshot."""
+        snapshot.externally_locked = self._is_locked_by_other_process(snapshot)
+
+    def _refresh_external_locks(self) -> None:
+        """Refresh cross-process lock state for loaded snapshots."""
+        for snapshot in self._snapshots.values():
+            self._refresh_external_lock(snapshot)
+
     def _snap_dir_name(self, snap_id: int) -> str:
         """Generate snapshot directory name."""
         return f"snap-{snap_id:06d}"
@@ -372,7 +451,15 @@ class SnapshotManager:
                 raise SnapshotNotFoundError(f"Snapshot {snapshot_id} not found")
 
             snapshot = self._snapshots[snapshot_id]
+            if snapshot.refcount == 0:
+                self._refresh_external_lock(snapshot)
+                if snapshot.externally_locked:
+                    raise SnapshotInUseError(
+                        f"Snapshot {snapshot_id} is locked by another process"
+                    )
+                self._acquire_process_lock(snapshot)
             snapshot.refcount += 1
+            snapshot.externally_locked = False
 
             logger.debug(f"Acquired snapshot {snapshot_id}, refcount={snapshot.refcount}")
             return SnapshotHandle(snapshot, self)
@@ -387,6 +474,8 @@ class SnapshotManager:
                 return
 
             snapshot.refcount = max(0, snapshot.refcount - 1)
+            if snapshot.refcount == 0:
+                self._release_process_lock(snapshot)
             logger.debug(f"Released snapshot {snapshot.id}, refcount={snapshot.refcount}")
 
     def get_snapshot(self, snapshot_id: int) -> Snapshot | None:
@@ -397,6 +486,7 @@ class SnapshotManager:
     def get_snapshots(self) -> list[Snapshot]:
         """Get all snapshots, ordered by creation time (oldest first)."""
         with self._lock:
+            self._refresh_external_locks()
             return sorted(self._snapshots.values(), key=lambda s: s.created_at)
 
     def get_deletable_snapshots(self) -> list[Snapshot]:
@@ -426,10 +516,11 @@ class SnapshotManager:
                 return False
 
             snapshot = self._snapshots[snapshot_id]
+            self._refresh_external_lock(snapshot)
 
-            if snapshot.refcount > 0:
+            if not snapshot.is_deletable:
                 raise SnapshotInUseError(
-                    f"Snapshot {snapshot_id} has {snapshot.refcount} active references"
+                    f"Snapshot {snapshot_id} is in use"
                 )
 
             # Remove from tracking first

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,22 +1,21 @@
 """Tests for snapshot management."""
 
-from pathlib import Path
-from datetime import datetime
 import threading
 import time
+from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 from teslausb.filesystem import MockFilesystem
 from teslausb.snapshot import (
     Snapshot,
-    SnapshotHandle,
-    SnapshotManager,
-    SnapshotState,
+    SnapshotCreationError,
     SnapshotError,
     SnapshotInUseError,
+    SnapshotManager,
     SnapshotNotFoundError,
-    SnapshotCreationError,
+    SnapshotState,
 )
 
 
@@ -57,6 +56,18 @@ class TestSnapshot:
             path=Path("/snap"),
             created_at=datetime.now(),
             refcount=1,
+        )
+
+        assert snap.state == SnapshotState.ARCHIVING
+        assert not snap.is_deletable
+
+    def test_snapshot_not_deletable_when_locked_by_another_process(self):
+        """Test that externally locked snapshots are not deletable."""
+        snap = Snapshot(
+            id=1,
+            path=Path("/snap"),
+            created_at=datetime.now(),
+            externally_locked=True,
         )
 
         assert snap.state == SnapshotState.ARCHIVING
@@ -268,6 +279,73 @@ class TestSnapshotManager:
 
         handle.release()
 
+    def test_get_deletable_snapshots_excludes_external_locks(
+        self,
+        mock_fs: MockFilesystem,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test externally locked snapshots are not reported as deletable."""
+        manager = SnapshotManager(
+            fs=mock_fs,
+            cam_disk_path=Path("/backingfiles/cam_disk.bin"),
+            snapshots_path=Path("/backingfiles/snapshots"),
+        )
+
+        snap1 = manager.create_snapshot()
+        snap2 = manager.create_snapshot()
+
+        monkeypatch.setattr(
+            manager,
+            "_is_locked_by_other_process",
+            lambda snapshot: snapshot.id == snap2.id,
+        )
+
+        snapshots = manager.get_snapshots()
+        by_id = {snapshot.id: snapshot for snapshot in snapshots}
+        assert by_id[snap1.id].state == SnapshotState.READY
+        assert by_id[snap2.id].state == SnapshotState.ARCHIVING
+
+        deletable = manager.get_deletable_snapshots()
+        assert [snapshot.id for snapshot in deletable] == [snap1.id]
+
+    def test_delete_snapshot_excludes_external_locks(
+        self,
+        mock_fs: MockFilesystem,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test externally locked snapshots cannot be deleted."""
+        manager = SnapshotManager(
+            fs=mock_fs,
+            cam_disk_path=Path("/backingfiles/cam_disk.bin"),
+            snapshots_path=Path("/backingfiles/snapshots"),
+        )
+
+        snapshot = manager.create_snapshot()
+        monkeypatch.setattr(manager, "_is_locked_by_other_process", lambda snap: True)
+
+        with pytest.raises(SnapshotInUseError):
+            manager.delete_snapshot(snapshot.id)
+
+        assert manager.get_snapshot(snapshot.id) is not None
+
+    def test_acquire_snapshot_excludes_external_locks(
+        self,
+        mock_fs: MockFilesystem,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test externally locked snapshots cannot be acquired."""
+        manager = SnapshotManager(
+            fs=mock_fs,
+            cam_disk_path=Path("/backingfiles/cam_disk.bin"),
+            snapshots_path=Path("/backingfiles/snapshots"),
+        )
+
+        snapshot = manager.create_snapshot()
+        monkeypatch.setattr(manager, "_is_locked_by_other_process", lambda snap: True)
+
+        with pytest.raises(SnapshotInUseError):
+            manager.acquire(snapshot.id)
+
     def test_snapshot_session(self, mock_fs: MockFilesystem):
         """Test snapshot_session context manager."""
         manager = SnapshotManager(
@@ -417,7 +495,11 @@ class TestPowerCutRecovery:
     is incomplete and will be cleaned up on restart.
     """
 
-    def test_incomplete_snapshot_without_toc_is_cleaned_up(self, mock_fs: MockFilesystem, tmp_path: Path):
+    def test_incomplete_snapshot_without_toc_is_cleaned_up(
+        self,
+        mock_fs: MockFilesystem,
+        tmp_path: Path,
+    ):
         """Test that snapshots without .toc file are cleaned up on restart."""
         snapshots_path = tmp_path / "snapshots"
         cam_disk = tmp_path / "cam.bin"
@@ -465,7 +547,9 @@ class TestPowerCutRecovery:
         mock_fs.mkdir(partial_delete_snap)
         mock_fs.write_text(
             partial_delete_snap / "metadata.json",
-            '{"id": 2, "path": "' + str(partial_delete_snap) + '", "created_at": "2024-01-01T00:00:00"}'
+            '{"id": 2, "path": "'
+            + str(partial_delete_snap)
+            + '", "created_at": "2024-01-01T00:00:00"}'
         )
         mock_fs.write_bytes(partial_delete_snap / "snap.bin", b"data")
         # Note: NO .toc file (was deleted during deletion process)
@@ -512,7 +596,11 @@ class TestPowerCutRecovery:
         assert snapshots[0].state == SnapshotState.READY
         assert snapshots[0].refcount == 0
 
-    def test_legacy_snapshot_without_metadata_is_reconstructed(self, mock_fs: MockFilesystem, tmp_path: Path):
+    def test_legacy_snapshot_without_metadata_is_reconstructed(
+        self,
+        mock_fs: MockFilesystem,
+        tmp_path: Path,
+    ):
         """Test that legacy snapshots without metadata.json are reconstructed."""
         snapshots_path = tmp_path / "snapshots"
         cam_disk = tmp_path / "cam.bin"


### PR DESCRIPTION
## Summary

Adds cross-process snapshot safety using an advisory kernel lock on each acquired snapshot. `teslausb status`, `teslausb snapshots`, and `teslausb clean` can now see when another running process is using a snapshot instead of treating it as stale/deletable.

## Why

Snapshot refcounts were process-local. A separate CLI invocation loaded active snapshots with refcount 0, which made live archive snapshots appear stale and potentially deletable.

## Validation

- `uv run --extra test pytest tests/test_snapshot.py tests/test_coordinator.py tests/test_archive.py -q`
- `uv run --extra test pytest tests --ignore=tests/integration -q`
- `uv run --extra dev ruff check src/teslausb/snapshot.py tests/test_snapshot.py`

Full integration tests were not run locally because this macOS environment lacks Linux tools such as `losetup` and `mkfs.xfs`.