### PR TITLE
[codex] Report archived byte counts

### DIFF
--- a/src/teslausb/archive.py
+++ b/src/teslausb/archive.py
@@ -9,15 +9,16 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from threading import Event
-from typing import Callable, Iterator
 
 from .filesystem import Filesystem, FilesystemError, RealFilesystem
 from .snapshot import SnapshotHandle, SnapshotManager
@@ -234,6 +235,28 @@ class RcloneBackend(ArchiveBackend):
             logger.warning(f"Could not scan directory {src}: {e}")
         return files
 
+    def _decode_output(self, output: bytes | None) -> str:
+        """Decode subprocess output."""
+        if not output:
+            return ""
+        return output.decode(errors="replace")
+
+    def _parse_copied_path(self, line: str) -> str | None:
+        """Parse the relative path from an rclone copied-file log line."""
+        marker = ": Copied ("
+        if marker not in line:
+            return None
+
+        prefix, _, _ = line.partition(marker)
+        match = re.search(r"INFO\s+:\s*(?P<path>.+)$", prefix)
+        rel_path = match.group("path").strip() if match else prefix.strip()
+        return rel_path.lstrip("/") if rel_path else None
+
+    def _sum_file_sizes(self, files: list[ArchivedFile], relative_paths: set[str]) -> int:
+        """Sum sizes for scanned files whose relative paths match rclone output."""
+        by_path = {file.relative_path: file for file in files}
+        return sum(by_path[path].size for path in relative_paths if path in by_path)
+
     def copy_directory(self, src: Path, dst_name: str) -> CopyResult:
         """Copy a directory using rclone copy.
 
@@ -258,23 +281,29 @@ class RcloneBackend(ArchiveBackend):
         try:
             result = subprocess.run(
                 cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 timeout=self.timeout,
                 check=False,
             )
 
             # Parse output for stats
             files_transferred = 0
-            bytes_transferred = 0
-            output = result.stderr.decode() if result.stderr else ""
+            copied_paths: set[str] = set()
+            output = "\n".join(
+                text for stream in (result.stdout, result.stderr)
+                if (text := self._decode_output(stream))
+            )
 
             for line in output.splitlines():
                 logger.debug(f"rclone: {line}")
                 # Count individual file copies (most reliable across rclone versions)
                 # Lines look like: "<6>INFO  : filename.mp4: Copied (new)"
-                if ": Copied (" in line:
+                copied_path = self._parse_copied_path(line)
+                if copied_path:
                     files_transferred += 1
+                    copied_paths.add(copied_path)
+
+            bytes_transferred = self._sum_file_sizes(archived_files, copied_paths)
 
             if result.returncode != 0:
                 error_msg = output.strip().split("\n")[-1] if output else "Unknown error"
@@ -544,7 +573,7 @@ class ArchiveManager:
         # Collect all directories, then sort by depth (deepest first)
         dirs_to_check: list[Path] = []
         try:
-            for dirpath, dirnames, filenames in self.fs.walk(base_path):
+            for dirpath, dirnames, _filenames in self.fs.walk(base_path):
                 for dirname in dirnames:
                     dirs_to_check.append(Path(dirpath) / dirname)
         except (OSError, FilesystemError):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,12 +1,11 @@
 """Tests for archive management."""
 
+import subprocess
 from pathlib import Path
 
-import pytest
-
 from teslausb.archive import (
-    ArchiveManager,
     ArchivedFile,
+    ArchiveManager,
     ArchiveResult,
     ArchiveState,
     CopyResult,
@@ -80,7 +79,8 @@ class TestArchiveManager:
         snapshot_mount = Path("/backingfiles/snapshots/snap-000000/mnt")
         dirs = manager._get_dirs_to_archive(snapshot_mount)
 
-        # Should find SavedClips, SentryClips, and Photobooth (RecentClips exists but not enabled by default)
+        # Should find SavedClips, SentryClips, and Photobooth.
+        # RecentClips exists but is not enabled by default.
         assert len(dirs) == 3
         dir_names = [d[1] for d in dirs]
         assert "SavedClips" in dir_names
@@ -380,6 +380,35 @@ class TestRcloneBackend:
         assert by_path["event1/front.mp4"].size == 1000
         assert by_path["event1/back.mp4"].size == 2000
 
+    def test_copy_directory_counts_copied_bytes(self, monkeypatch):
+        """Test copied-byte accounting uses rclone copied-file output."""
+        fs = MockFilesystem()
+        fs.mkdir(Path("/test/SavedClips/event1"), parents=True)
+        fs.write_text(Path("/test/SavedClips/event1/front.mp4"), "x" * 1000)
+        fs.write_text(Path("/test/SavedClips/event1/back.mp4"), "x" * 2000)
+        fs.write_text(Path("/test/SavedClips/event1/left.mp4"), "x" * 3000)
+
+        def run_success(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args[0],
+                returncode=0,
+                stderr=(
+                    b"<6>INFO  : event1/front.mp4: Copied (new)\n"
+                    b"<6>INFO  : event1/back.mp4: Unchanged skipping\n"
+                    b"<6>INFO  : event1/left.mp4: Copied (new)\n"
+                ),
+            )
+
+        monkeypatch.setattr(subprocess, "run", run_success)
+
+        backend = RcloneBackend(remote="gdrive", fs=fs)
+        result = backend.copy_directory(Path("/test/SavedClips"), "SavedClips")
+
+        assert result.success
+        assert result.files_transferred == 2
+        assert result.bytes_transferred == 4000
+        assert len(result.archived_files) == 3
+
 
 class TestDeleteArchivedFiles:
     """Tests for deleting archived files from cam_disk."""
@@ -432,7 +461,10 @@ class TestDeleteArchivedFiles:
 
         # Set up cam_disk structure - file has different size than archived
         fs.mkdir(Path("/cam_mount/TeslaCam/SavedClips/event1"), parents=True)
-        fs.write_text(Path("/cam_mount/TeslaCam/SavedClips/event1/front.mp4"), "x" * 1500)  # Different!
+        fs.write_text(
+            Path("/cam_mount/TeslaCam/SavedClips/event1/front.mp4"),
+            "x" * 1500,
+        )
 
         fs.mkdir(Path("/backingfiles/snapshots"), parents=True)
         snapshot_manager = SnapshotManager(
@@ -453,7 +485,7 @@ class TestDeleteArchivedFiles:
             state=ArchiveState.COMPLETED,
             archived_files={
                 "SavedClips": [
-                    ArchivedFile(relative_path="event1/front.mp4", size=1000),  # Archived size was 1000
+                    ArchivedFile(relative_path="event1/front.mp4", size=1000),
                 ],
             },
         )


### PR DESCRIPTION
## Summary

Populates `bytes_transferred` for successful rclone copy operations by matching rclone `Copied (...)` log lines back to the pre-scan file list.

## Why

Archive cycles could report a nonzero file count but `0 B`, which made logs and health checks misleading.

## Validation

- `uv run --extra test pytest tests/test_archive.py -q`
- `uv run --extra test pytest tests --ignore=tests/integration -q`
- `uv run --extra dev ruff check src/teslausb/archive.py tests/test_archive.py`

Full integration tests were not run locally because this macOS environment lacks Linux tools such as `losetup` and `mkfs.xfs`.